### PR TITLE
Configure for distribution on PyPI

### DIFF
--- a/.github/workflows/build-pypi.yml
+++ b/.github/workflows/build-pypi.yml
@@ -1,0 +1,52 @@
+name: Publish Python 🐍 distribution 📦 to PyPI and PyPI
+
+on: push
+
+jobs:
+  build:
+    name: Build distribution 📦
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        persist-credentials: false
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: "3.x"
+
+    - name: Install pypa/build
+      run: >-
+        python3 -m
+        pip install
+        build
+        --user
+    - name: Build a binary wheel and a source tarball
+      run: python3 -m build
+    - name: Store the distribution packages
+      uses: actions/upload-artifact@v4
+      with:
+        name: python-package-distributions
+        path: dist/
+
+  publish-to-pypi:
+    name: >-
+      Publish Python 🐍 distribution 📦 to PyPI
+    if: startsWith(github.ref, 'refs/tags/')  # only publish to PyPI on tag pushes
+    needs:
+    - build
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/p/tt-perf-report
+    permissions:
+      id-token: write  # IMPORTANT: mandatory for trusted publishing
+    steps:
+    - name: Download all the dists
+      uses: actions/download-artifact@v4
+      with:
+        name: python-package-distributions
+        path: dist/
+    - name: Publish distribution 📦 to PyPI
+      uses: pypa/gh-action-pypi-publish@release/v1

--- a/README.md
+++ b/README.md
@@ -4,6 +4,16 @@
 
 This tool analyzes performance traces from Metal operations, providing insights into throughput, bottlenecks, and optimization opportunities.
 
+## Installation
+
+This tool can be installed from PyPI:
+
+```bash
+pipx install tt-perf-report
+```
+
+Installing with pipx will automatically create a virtual environment and make the `tt-perf-report` command available.
+
 ## Generating Performance Traces
 
 1. Build Metal with performance tracing enabled:
@@ -11,7 +21,7 @@ This tool analyzes performance traces from Metal operations, providing insights 
 ./build_metal -p
 ```
 
-2. Run your test with the tracy module to capture traces:
+2. Run your test in TT-Metal with the tracy module to capture traces:
 ```bash
 python -m tracy -r -p -v -m pytest path/to/test.py
 ```
@@ -46,13 +56,13 @@ The output of the performance report is a table of operations. Each operation is
 Use `--id-range` to analyze specific sections:
 ```bash
 # Analyze ops 5 through 10
-python perf_report.py trace.csv --id-range 5-10
+tt-perf-report trace.csv --id-range 5-10
 
 # Analyze from op 31 onwards
-python perf_report.py trace.csv --id-range 31-
+tt-perf-report trace.csv --id-range 31-
 
 # Analyze up to op 12
-python perf_report.py trace.csv --id-range -12
+tt-perf-report trace.csv --id-range -12
 ```
 
 This is particularly useful for:
@@ -109,23 +119,23 @@ The tool automatically highlights potential optimization opportunities:
 Typical use:
 
 ```bash
-python perf_report.py trace.csv
+tt-perf-report trace.csv
 ```
 
 Build a table of all ops with no advice:
 
 ```bash
-python perf_report.py trace.csv --no-advice
+tt-perf-report trace.csv --no-advice
 ```
 
 View ops 100-200 with advice:
 
 ```bash
-python perf_report.py trace.csv --id-range 100-200
+tt-perf-report trace.csv --id-range 100-200
 ```
 
 Export the table of ops and columns as a CSV file:
 
 ```bash
-python perf_report.py trace.csv --csv my_report.csv
+tt-perf-report trace.csv --csv my_report.csv
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,22 @@
+[build-system]
+requires = ["setuptools", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "tt-perf-report"
+version = "1.0.0"
+description = "This tool analyzes performance traces from TT-Metal operations, providing insights into throughput, bottlenecks, and optimization opportunities."
+license = {file = "LICENSE"}
+readme = "README.md"
+keywords = ["tenstorrent", "tt-metal"]
+dependencies = ["pandas"]
+
+[project.scripts]
+tt-perf-report = "tt_perf_report.perf_report:main"
+
+[project.urls]
+Repository = "https://github.com/tenstorrent/tt-perf-report"
+
+[tool.setuptools]
+packages = ["tt_perf_report"]
+package-dir = {"" = "src"}

--- a/src/tt_perf_report/__init__.py
+++ b/src/tt_perf_report/__init__.py
@@ -1,0 +1,3 @@
+# SPDX-License-Identifier: Apache-2.0
+
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC


### PR DESCRIPTION
This PR adds a GitHub workflow file to build a package and publish it to PyPI.

The `pyproject.toml` configures `tt-perf-report` as a script, but this required passing a function name to run. For this to work, I did a minor refactor to move the code that was at the top level into the `main()` function and a new `parse_args()` function.

I moved some of the code from `main()` into a new function called `generate_perf_report()`. The motivation for this is to be able to generate the report from the Flask backend in ttnn-visualizer, without running this as a CLI script from Python. We will be able to include `tt-perf-report` in the dependencies, and do `from tt_perf_report.perf_report import generate_perf_report`, and run it without the CLI argument parsing.

I tested this with TestPyPI, and I was able to install and run it like this:

`pipx install tt-perf-report  --index-url https://test.pypi.org/simple/ --pip-args="--extra-index-url https://pypi.org/simple/"`

It's on TestPyPI here: https://test.pypi.org/project/tt-perf-report/

Once it's on the real PyPI we won't need the `--index-url` and `--pip-args` to install. Those are just to get `pipx` to use TestPyPI.

We will be updating the `pyproject.toml` and / or `requirements.txt` files inn ttnn-visualizer to list tt-perf-report as a dependency that is automatically installed, since we will import the `generate_perf_report()` function as mentioned above, and run it directly from Python. TT-Metal could do the same and include it in its Python dependencies, or it could direct users to use the `pipx install tt-perf-report` command to install this script, since it's not a core dependency of tt-metal.