### PR TITLE
Add matmul advice to CSV output

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "tt-perf-report"
-version = "1.0.2"
+version = "1.0.3"
 description = "This tool analyzes performance traces from TT-Metal operations, providing insights into throughput, bottlenecks, and optimization opportunities."
 license = {file = "LICENSE"}
 readme = "README.md"


### PR DESCRIPTION
This PR modifies the CSV output file to have an `Advice` column, which includes the matmul advice that was previously only printed to stdout and not saved to the CSV file when using the `--csv OUTPUT_FILE` option.

To do this, I've moved the logic that constructed the advice messages into a new function called `def generate_matmul_advice(op_data)`. It returns the message strings in a list, which are output the same way they previously were in the `print_matmul_advice` function, with the returned list being used to put the messages in the CSV also.

I considered several options on how to get an array of messages into a single column in the CSV. I went with separating the messages with a bullet character with spaces around it (` • `). This allows us to parse the strings back into a list, while keeping it human readable in the CSV. Alternatives might have been separating the messages with a comma, but commas could appear in the message and might break the parsing. We could have dumped the list of messages to JSON and put that in the CSV column. Or we could have had it be multi-line in the CSV column, with each advice message separated by a newline, but I didn't go with that approach because the CSV file isn't quoting text strings and it could break any existing tools doing simple CSV parsing without handling quoted values well. I think the bullet point is ok, but open to alternatives.

There's a minor change to the CSV generation to use `csv.DictWriter` from the standard library.

The `- ` prefixes are removed the advice messages, in the new `generate_matmul_advice` function, because I didn't want those in the CSV column, but that functionality is preserved in by printing the dashes to the terminal when looping over the advice list in `print_matmul_advice`.

The feature being added here to add the advice column to the CSV respects the existing `--no-advice` option, and won't add it when that CLI flag is passed.