### PR TITLE
analyze_conv; basic version; halo ignored

### DIFF
--- a/src/tt_perf_report/perf_report.py
+++ b/src/tt_perf_report/perf_report.py
@@ -279,12 +279,11 @@ def analyze_matmul(row):
 def analyze_conv(row):
     duration_s = row["DEVICE KERNEL DURATION [ns]"] * 1e-9
 
-    core_count = row["CORE COUNT"]
+    core_count = 64 # we decided to normalize to the max core count
     math_fidelity = row["MATH FIDELITY"]
 
     # Check for DRAM-sharded program config
     attributes = row["ATTRIBUTES"] if pd.notna(row["ATTRIBUTES"]) else ""
-    is_dram_sharded = "MatmulMultiCoreReuseMultiCastDRAMShardedProgramConfig" in attributes
 
     peak_flops_value = tflops_per_core(math_fidelity) * 1e12 * core_count
 


### PR DESCRIPTION
Added more detailed print for conv ops. 

Piggy-back on matmul calculus where 
M = N * H_out * W_out
K = C_in * KernelWindow_H * KernelWindow_W  
N = C_out

Real deal would be to make everything from halo to optimized conv into duration account. This is a good start

<img width="959" alt="image" src="https://github.com/user-attachments/assets/df2328fe-2fbc-41fd-b591-13b1c2fdcf3b" />
