### PR TITLE
Maintain compatibility with the original CSV format

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "tt-perf-report"
-version = "1.1.0"
+version = "1.1.1"
 description = "This tool analyzes performance traces from TT-Metal operations, providing insights into throughput, bottlenecks, and optimization opportunities."
 license = {file = "LICENSE"}
 readme = "README.md"


### PR DESCRIPTION
A format change was made to the `ops_perf_results_*.csv` in tt-metal:
https://github.com/tenstorrent/tt-metal/pull/26695

A fix was made in tt-perf-report to handle the updated format in PR #17. This fixed the issue for anyone generating reports in the latest version of tt-metal, with the latest version of tt-perf-report. The fix in #17 did not maintain backwards compatibility with the original CSV format, and that caused issues running the tt-perf-report tool from TTNN Visualizer.

The fix being made here modifies tt-perf-report so that it can still generate a report when the input file is in the original format, that didn't have the logical values in square brackets.