### PR TITLE
Fix/Stacked report host ops count

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "tt-perf-report"
-version = "1.1.5"
+version = "1.1.6"
 description = "This tool analyzes performance traces from TT-Metal operations, providing insights into throughput, bottlenecks, and optimization opportunities."
 license = {file = "LICENSE"}
 readme = "README.md"

--- a/src/tt_perf_report/perf_report.py
+++ b/src/tt_perf_report/perf_report.py
@@ -882,7 +882,7 @@ def generate_stacked_report(rows, visible_headers, stack_by_input0_layout:bool =
     # Group by the joined OP Code and aggregate the data
     stacked_df = df.groupby("OP Code Joined").agg(
         Device_Time_Sum_us=("Device Time", "sum"),
-        Ops_Count=("Device Time", "count"),
+        Ops_Count=("Device Time", "size"),
         Flops_min=("FLOPs %", "min"),
         Flops_max=("FLOPs %", "max"),
         Flops_mean=("FLOPs %", "mean"),
@@ -897,7 +897,6 @@ def generate_stacked_report(rows, visible_headers, stack_by_input0_layout:bool =
     else:
         stacked_df["%"] = 0
         
-    stacked_df["%"] = (stacked_df["Device_Time_Sum_us"] / total_device_time) * 100
     # Reorder columns to move Device_Time_Percentage to be the 3rd column
     cols = stacked_df.columns.tolist()
     cols.insert(0, cols.pop(cols.index("%")))


### PR DESCRIPTION
Changed method from `count` (which ignores null values) to `size` (which does not). This allows us to count host ops in the stacked report. 

The change will mean rows with device time of null will also be included for all stacked op counts, but in the reports I've tested this doesn't change the count. Assume it's unlikely device times would be null for device ops, but if they are it's probably good to count them anyway.