### PR TITLE
fix signposts filtering in the stacked report

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "tt-perf-report"
-version = "1.1.6"
+version = "1.1.7"
 description = "This tool analyzes performance traces from TT-Metal operations, providing insights into throughput, bottlenecks, and optimization opportunities."
 license = {file = "LICENSE"}
 readme = "README.md"


### PR DESCRIPTION
#25 didn't work as "rows" do not carry "OP Type" information; that was in "df" table.

Added less-elegant solution that appends "(signpost)" to OP Code if it's a signpost. 
Also, I think op counting didnt work, it should be fixed now.

Can add non-visible filed OP Type to all fields in "rows" and #25 will also work. Opted for naming as it might be useful to see that in the report. 

Tested manually filtering by signposts, no signposts, and signposts - all appears to work. We definitely need some tests here.

<img width="1310" height="451" alt="image" src="https://github.com/user-attachments/assets/c81134f9-b926-4fda-9036-8a21eafc35ab" />
<img width="1232" height="376" alt="image" src="https://github.com/user-attachments/assets/3501e269-cdfd-48b4-9eff-7f0474f6c66e" />
