### PR TITLE
Fix/Host Ops Never Returned

### DIFF
--- a/src/tt_perf_report/perf_report.py
+++ b/src/tt_perf_report/perf_report.py
@@ -1140,7 +1140,15 @@ def merge_device_rows(df):
         global_index += 1
 
     all_rows = merged_blocks + non_device_rows
-    return pd.DataFrame(all_rows)
+    result_df = pd.DataFrame(all_rows)
+    
+    # Restore chronological order by sorting by original row position or timestamp
+    if "ORIGINAL_ROW" in result_df.columns:
+        result_df = result_df.sort_values(by="ORIGINAL_ROW").reset_index(drop=True)
+    elif "HOST START TS" in result_df.columns:
+        result_df = result_df.sort_values(by="HOST START TS").reset_index(drop=True)
+    
+    return result_df
 
 
 def parse_id_range(id_range_str):


### PR DESCRIPTION
Host ops are being filtered out regardless of whether `--no-host-ops` is used when merging device rows.

**Before**
<img width="1254" height="897" alt="Screenshot 2025-12-08 at 10 38 19 AM" src="https://github.com/user-attachments/assets/7f8da1a3-14e0-4b39-8286-09f20ae7e92a" />

**After**
<img width="1254" height="897" alt="Screenshot 2025-12-08 at 10 37 48 AM" src="https://github.com/user-attachments/assets/01307bce-e70a-4d19-b0d1-160b0fd1388f" />
