### PR TITLE
Fix/Zero Rows Error

### DIFF
--- a/src/tt_perf_report/perf_report.py
+++ b/src/tt_perf_report/perf_report.py
@@ -1289,7 +1289,7 @@ def generate_perf_report(
     df = filter_by_signpost(df, start_signpost, end_signpost, ignore_signposts)
     unique_devices = df["DEVICE ID"].nunique()
 
-    if no_merge_devices and "DEVICE ID" in df.columns and df["DEVICE ID"].nunique() > 1:
+    if no_merge_devices and "DEVICE ID" in df.columns and unique_devices > 1:
         print(colored(f"Detected data from {unique_devices} devices. Keeping separate device data...", "cyan"))
     elif unique_devices == 0:
         print(colored("No device operations found in the CSV data.", "yellow"))


### PR DESCRIPTION
Avoids throwing an error when filters return zero device rows.

**Before**
Without `--start-signpost`
<img width="1254" height="316" alt="Image" src="https://github.com/user-attachments/assets/52b83a88-ae3c-48c1-8d16-9c9eb72927fd" />

With `--start-signpost`
<img width="1254" height="303" alt="Image" src="https://github.com/user-attachments/assets/bd5f9935-15c6-457e-90bd-ed54aed58d2b" />

**After**
Without `--start-signpost`
<img width="1254" height="235" alt="Image" src="https://github.com/user-attachments/assets/4f0c3f41-e683-4a74-8dac-70861dbb6bbc" />

With `--start-signpost`
<img width="1254" height="303" alt="Image" src="https://github.com/user-attachments/assets/a73cf309-332b-4e03-85d7-97711ff4b16b" />

Closes https://github.com/tenstorrent/tt-perf-report/issues/33.