### PR TITLE
Fix/Update Op To Op Gap Calc

### DIFF
--- a/src/tt_perf_report/perf_report.py
+++ b/src/tt_perf_report/perf_report.py
@@ -1317,7 +1317,6 @@ def generate_perf_report(
         df = merge_device_rows(df)
 
     rows = []
-    prev_row = None
     prev_non_signpost_row = None
     device_ops = 0
     host_ops = 0


### PR DESCRIPTION
When signposts are present, the op-to-top gap calculation doesn't work because it tries to base it on a signpost which doesn't have the appropriate data. It also affects `Total %` which then also affects how rows get colourised. 

**Before** (look at Op 100)
<img width="1027" height="578" alt="Screenshot 2025-12-15 at 11 27 38 AM" src="https://github.com/user-attachments/assets/877dcf1a-77ac-42ab-8a34-ced651454bc8" />

**After** (look at Op 100)
<img width="1027" height="578" alt="Screenshot 2025-12-15 at 11 28 54 AM" src="https://github.com/user-attachments/assets/65777e9f-cc2c-4139-bc83-ee300d131d5f" />
