### PR TITLE
Add CCL utilization for DeepSeek v3 prefill ops

### DIFF
--- a/src/tt_perf_report/perf_report.py
+++ b/src/tt_perf_report/perf_report.py
@@ -693,19 +693,6 @@ def analyze_ccl(row, csv_format=CsvFormat.V2, arch_spec: ArchitectureSpec = None
     # Parse attributes
     attributes = row["ATTRIBUTES"] if pd.notna(row["ATTRIBUTES"]) else ""
 
-    # Parse ring_size from attributes
-    ring_size = None
-    try:
-        if "ring_size" in attributes:
-            ring_size_str = attributes.split("'ring_size': '")[1].split("'")[0]
-            ring_size = int(ring_size_str)
-    except (IndexError, ValueError, AttributeError):
-        pass
-
-    # Default ring_size if not found
-    if ring_size is None:
-        ring_size = 4
-
     # Parse num_links from attributes
     num_links = None
     try:
@@ -728,6 +715,14 @@ def analyze_ccl(row, csv_format=CsvFormat.V2, arch_spec: ArchitectureSpec = None
     except (IndexError, ValueError, AttributeError):
         pass
 
+    dispatch_group_size = None
+    try:
+        if "dispatch_group_size" in attributes:
+            dispatch_group_size_str = attributes.split("'dispatch_group_size': '")[1].split("'")[0]
+            dispatch_group_size = int(dispatch_group_size_str)
+    except (IndexError, ValueError, AttributeError):
+        pass
+
     # Calculate tensor sizes for input_0
     input_0_size = (
         get_value_physical_logical(row[get_column_name("INPUT_0_Z", csv_format)])
@@ -735,20 +730,6 @@ def analyze_ccl(row, csv_format=CsvFormat.V2, arch_spec: ArchitectureSpec = None
         * get_value_physical_logical(row[get_column_name("INPUT_0_X", csv_format)])
         * get_datatype_size(row["INPUT_0_DATATYPE"])
     )
-
-    # Calculate tensor sizes for input_1 (if exists)
-    input_1_size = 0
-    input_1_col = get_column_name("INPUT_1_Z", csv_format)
-    if input_1_col in row.index and pd.notna(row[input_1_col]) and pd.notna(row.get("INPUT_1_DATATYPE")):
-        try:
-            input_1_size = (
-                get_value_physical_logical(row[get_column_name("INPUT_1_Z", csv_format)])
-                * get_value_physical_logical(row[get_column_name("INPUT_1_Y", csv_format)])
-                * get_value_physical_logical(row[get_column_name("INPUT_1_X", csv_format)])
-                * get_datatype_size(row["INPUT_1_DATATYPE"])
-            )
-        except (KeyError, ValueError, TypeError):
-            input_1_size = 0
 
     # Calculate tensor sizes for output_0
     output_0_size = (
@@ -758,37 +739,43 @@ def analyze_ccl(row, csv_format=CsvFormat.V2, arch_spec: ArchitectureSpec = None
         * get_datatype_size(row["OUTPUT_0_DATATYPE"])
     )
 
-    # Calculate tensor sizes for output_1 (if exists)
-    output_1_size = 0
-    output_1_col = get_column_name("OUTPUT_1_Z", csv_format)
-    if output_1_col in row.index and pd.notna(row[output_1_col]) and pd.notna(row.get("OUTPUT_1_DATATYPE")):
-        try:
-            output_1_size = (
-                get_value_physical_logical(row[get_column_name("OUTPUT_1_Z", csv_format)])
-                * get_value_physical_logical(row[get_column_name("OUTPUT_1_Y", csv_format)])
-                * get_value_physical_logical(row[get_column_name("OUTPUT_1_X", csv_format)])
-                * get_datatype_size(row["OUTPUT_1_DATATYPE"])
-            )
-        except (KeyError, ValueError, TypeError):
-            output_1_size = 0
+    # Calculate ring_size from tensor dimensions
+    ring_size = None
+    if "AllGather" in op_code and input_0_size > 0:
+        # AllGather: output is ring_size times larger than input
+        ring_size = output_0_size // input_0_size
+    elif "ReduceScatter" in op_code and output_0_size > 0:
+        # ReduceScatter: input is ring_size times larger than output
+        ring_size = input_0_size // output_0_size
 
     # Select tensor size (M) based on operation type
     if "ReduceScatter" in op_code:
         tensor_size = input_0_size
     elif "AllGather" in op_code:
         tensor_size = output_0_size
+    elif "Dispatch" in op_code:
+        tensor_size = input_0_size
+    elif "Combine" in op_code:
+        tensor_size = output_0_size
+        tensor_size /= get_value_physical_logical(row[get_column_name("OUTPUT_0_Y", csv_format)])
     else:
-        tensor_size = max(input_0_size, input_1_size, output_0_size, output_1_size)
+        tensor_size = max(input_0_size, output_0_size)
 
     # Calculate effective data transferred per node (Algorithm Bus Bandwidth model)
-    if ring_size > 1:
-        # Standard Ring algorithm data volume per node: M * (P-1) / P
+    if ring_size is not None and ring_size > 1:
+        # All-Gather & Reduce-Scatter logic: Bottleneck scales flatly with (P-1)/P
         effective_data_moved_bytes = tensor_size * (ring_size - 1) / ring_size
-        
-        # Apply the 2x congestion penalty for Linear topology
         if topology == "Topology::Linear":
             effective_data_moved_bytes *= 2
+    elif dispatch_group_size is not None and dispatch_group_size > 1:
+        if topology == "Topology::Linear":
+            # Line topology: effective size = M * P^2 / 4
+            effective_data_moved_bytes = tensor_size * (dispatch_group_size ** 2) / 4
+        else:
+            # Ring topology: effective size = M * P^2 / 8
+            effective_data_moved_bytes = tensor_size * (dispatch_group_size ** 2) / 8
     else:
+        # Default fallback
         effective_data_moved_bytes = tensor_size
 
     # Calculate speed (Throughput per node) and utilization
@@ -988,7 +975,7 @@ def analyze_op(row, prev_row, csv_format=CsvFormat.V2, arch_spec: ArchitectureSp
             if math_fidelity
             else None
         )
-    elif any(x in op_code.raw_value for x in ["AllGather", "ReduceScatter", "AllReduce"]) and "LayerNorm" not in op_code.raw_value:
+    elif any(x in op_code.raw_value for x in ["AllGather", "ReduceScatter", "AllReduce", "Dispatch", "Combine"]) and "LayerNorm" not in op_code.raw_value:
         # Analyze CCL operations
         (
             ccl_speed,

--- a/src/tt_perf_report/perf_report.py
+++ b/src/tt_perf_report/perf_report.py
@@ -10,6 +10,7 @@ import sys
 from collections import defaultdict
 from dataclasses import dataclass
 from typing import Any, ClassVar, Dict, List, Optional, Union
+import pandas as pd
 
 try:
     import matplotlib.pyplot as plt
@@ -686,12 +687,6 @@ def analyze_matmul(row, csv_format=CsvFormat.V2, arch_spec: ArchitectureSpec = N
 
 
 def analyze_ccl(row, csv_format=CsvFormat.V2, arch_spec: ArchitectureSpec = None, op_code: str = ""):
-    """
-    Analyze CCL (Collective Communications Library) operations.
-
-    Formula: data = tensor_size * (ring_size - 1) / ring_size
-    Utilization = (data / duration) / peak_bandwidth
-    """
     if arch_spec is None:
         arch_spec = ArchitectureSpec.from_name("wormhole")
 
@@ -777,7 +772,7 @@ def analyze_ccl(row, csv_format=CsvFormat.V2, arch_spec: ArchitectureSpec = None
         except (KeyError, ValueError, TypeError):
             output_1_size = 0
 
-    # Select tensor size based on operation type
+    # Select tensor size (M) based on operation type
     if "ReduceScatter" in op_code:
         tensor_size = input_0_size
     elif "AllGather" in op_code:
@@ -785,21 +780,34 @@ def analyze_ccl(row, csv_format=CsvFormat.V2, arch_spec: ArchitectureSpec = None
     else:
         tensor_size = max(input_0_size, input_1_size, output_0_size, output_1_size)
 
-    # Calculate data transferred: (ring_size - 1) * tensor_size
+    # Calculate effective data transferred per node (Algorithm Bus Bandwidth model)
     if ring_size > 1:
-        ccl_data_transferred_bytes = tensor_size * (ring_size - 1)
-        ccl_data_transferred_bytes *= 2 if topology == "Topology::Linear" else 1
+        # Standard Ring algorithm data volume per node: M * (P-1) / P
+        effective_data_moved_bytes = tensor_size * (ring_size - 1) / ring_size
+        
+        # Apply the 2x congestion penalty for Linear topology
+        if topology == "Topology::Linear":
+            effective_data_moved_bytes *= 2
     else:
-        ccl_data_transferred_bytes = tensor_size
+        effective_data_moved_bytes = tensor_size
 
-    # Calculate speed and utilization
+    # Calculate speed (Throughput per node) and utilization
     duration_s = row["DEVICE KERNEL DURATION [ns]"] * 1e-9
-    ccl_speed_gb_s = (ccl_data_transferred_bytes / duration_s) / 1e9 if ccl_data_transferred_bytes > 0 and duration_s > 0 else None
+    
+    if effective_data_moved_bytes > 0 and duration_s > 0:
+        ccl_speed_gb_s = (effective_data_moved_bytes / duration_s) / 1e9
+    else:
+        ccl_speed_gb_s = None
 
-    # Peak bandwidth = eth_bandwidth × num_links
-    peak_ccl_bandwidth = arch_spec.eth_bandwidth_gb_s * num_links * ring_size
-    ccl_percentage = (ccl_speed_gb_s / peak_ccl_bandwidth) * 100 if ccl_speed_gb_s is not None else None
+    # Peak bandwidth per node = eth_bandwidth × num_links
+    peak_per_node_gb_s = arch_spec.eth_bandwidth_gb_s * num_links
+    
+    if ccl_speed_gb_s is not None:
+        ccl_percentage = (ccl_speed_gb_s / peak_per_node_gb_s) * 100 
+    else:
+        ccl_percentage = None
 
+    # Return the per-node algorithm throughput and the utilization percentage
     return (ccl_speed_gb_s, ccl_percentage)
 
 

--- a/src/tt_perf_report/perf_report.py
+++ b/src/tt_perf_report/perf_report.py
@@ -743,28 +743,34 @@ def analyze_ccl(row, csv_format=CsvFormat.V2, arch_spec: ArchitectureSpec = None
         num_routed_experts = 256
 
     # Calculate tensor sizes for input_0
-    input_0_size = (
-        get_value_physical_logical(row[get_column_name("INPUT_0_Z", csv_format)])
-        * get_value_physical_logical(row[get_column_name("INPUT_0_Y", csv_format)])
-        * get_value_physical_logical(row[get_column_name("INPUT_0_X", csv_format)])
-        * get_datatype_size(row["INPUT_0_DATATYPE"])
-    )
+    input_0_size = 0
+    try:
+        input_0_size = (
+            get_value_physical_logical(row[get_column_name("INPUT_0_Z", csv_format)])
+            * get_value_physical_logical(row[get_column_name("INPUT_0_Y", csv_format)])
+            * get_value_physical_logical(row[get_column_name("INPUT_0_X", csv_format)])
+            * get_datatype_size(row["INPUT_0_DATATYPE"])
+        )
+    except (KeyError, ValueError, TypeError):
+        pass
 
     # Calculate tensor sizes for output_0
-    output_0_size = (
-        get_value_physical_logical(row[get_column_name("OUTPUT_0_Z", csv_format)])
-        * get_value_physical_logical(row[get_column_name("OUTPUT_0_Y", csv_format)])
-        * get_value_physical_logical(row[get_column_name("OUTPUT_0_X", csv_format)])
-        * get_datatype_size(row["OUTPUT_0_DATATYPE"])
-    )
+    output_0_size = 0
+    try:
+        output_0_size = (
+            get_value_physical_logical(row[get_column_name("OUTPUT_0_Z", csv_format)])
+            * get_value_physical_logical(row[get_column_name("OUTPUT_0_Y", csv_format)])
+            * get_value_physical_logical(row[get_column_name("OUTPUT_0_X", csv_format)])
+            * get_datatype_size(row["OUTPUT_0_DATATYPE"])
+        )
+    except (KeyError, ValueError, TypeError):
+        pass
 
     # Calculate ring_size from tensor dimensions
     ring_size = None
     if "AllGather" in op_code and input_0_size > 0:
-        # AllGather: output is ring_size times larger than input
         ring_size = output_0_size // input_0_size
     elif "ReduceScatter" in op_code and output_0_size > 0:
-        # ReduceScatter: input is ring_size times larger than output
         ring_size = input_0_size // output_0_size
 
     # Select tensor size (M) based on operation type
@@ -776,26 +782,25 @@ def analyze_ccl(row, csv_format=CsvFormat.V2, arch_spec: ArchitectureSpec = None
         tensor_size = input_0_size * dispatch_group_size * num_experts_per_tok / num_routed_experts
     elif "CombineDeviceOperation" in op_code:
         tensor_size = output_0_size
-        tensor_size /= get_value_physical_logical(row[get_column_name("OUTPUT_0_Y", csv_format)])
+        y_dim = get_value_physical_logical(row[get_column_name("OUTPUT_0_Y", csv_format)])
+        if y_dim > 0: # Added safety check against zero division
+            tensor_size /= y_dim
         tensor_size *= dispatch_group_size * num_experts_per_tok / num_routed_experts
     else:
         tensor_size = max(input_0_size, output_0_size)
 
     # Calculate effective data transferred per node (Algorithm Bus Bandwidth model)
     if ring_size is not None and ring_size > 1:
-        # All-Gather & Reduce-Scatter logic: Bottleneck scales flatly with (P-1)/P
+        # All-Gather & Reduce-Scatter logic
         effective_data_moved_bytes = tensor_size * (ring_size - 1) / ring_size
         if topology == "Topology::Linear":
             effective_data_moved_bytes *= 2
     elif dispatch_group_size is not None and dispatch_group_size > 1:
         if topology == "Topology::Linear":
-            # Line topology: effective size = M * P^2 / 4
             effective_data_moved_bytes = tensor_size * (dispatch_group_size ** 2) / 4
         else:
-            # Ring topology: effective size = M * P^2 / 8
             effective_data_moved_bytes = tensor_size * (dispatch_group_size ** 2) / 8
     else:
-        # Default fallback
         effective_data_moved_bytes = tensor_size
 
     # Calculate speed (Throughput per node) and utilization
@@ -814,7 +819,6 @@ def analyze_ccl(row, csv_format=CsvFormat.V2, arch_spec: ArchitectureSpec = None
     else:
         ccl_percentage = None
 
-    # Return the per-node algorithm throughput and the utilization percentage
     return (ccl_speed_gb_s, ccl_percentage)
 
 

--- a/src/tt_perf_report/perf_report.py
+++ b/src/tt_perf_report/perf_report.py
@@ -287,7 +287,7 @@ ArchitectureSpec.register(ArchitectureSpec(
     name="wormhole",
     worker_cores=64,  # N150 and N300 with ETH dispatch
     dram_bandwidth_gb_s=288,
-    eth_bandwidth_gb_s=50,  # 50 GB/s per link
+    eth_bandwidth_gb_s=25,  # 25 GB/s bidirectional per link
     tflops_hifi4=74 / 72,
     tflops_hifi2=148 / 72,
     tflops_lofi=262 / 72,
@@ -297,7 +297,7 @@ ArchitectureSpec.register(ArchitectureSpec(
     name="blackhole",
     worker_cores=130,  # P150
     dram_bandwidth_gb_s=512,
-    eth_bandwidth_gb_s=50,  # 50 GB/s per link
+    eth_bandwidth_gb_s=50,  # 50 GB/s bidirectional per link
     tflops_hifi4=4096 * 1.35 / 1000 / 4,
     tflops_hifi2=4096 * 1.35 / 1000 / 2,
     tflops_lofi=4096 * 1.35 / 1000,
@@ -307,7 +307,7 @@ ArchitectureSpec.register(ArchitectureSpec(
     name="bh20",
     worker_cores=20,   # N1-emu
     dram_bandwidth_gb_s=512,
-    eth_bandwidth_gb_s=50,  # 50 GB/s per link
+    eth_bandwidth_gb_s=25,  # 25 GB/s bidirectional per link
     tflops_hifi4=4096 * 1.35 / 1000 / 4,
     tflops_hifi2=4096 * 1.35 / 1000 / 2,
     tflops_lofi=4096 * 1.35 / 1000,
@@ -317,7 +317,7 @@ ArchitectureSpec.register(ArchitectureSpec(
     name="n1",
     worker_cores=20,
     dram_bandwidth_gb_s=120,
-    eth_bandwidth_gb_s=50,  # 50 GB/s per link
+    eth_bandwidth_gb_s=25,  # 25 GB/s bidirectional per link
     tflops_hifi4=4096 * 0.65 / 1000 / 4,
     tflops_hifi2=4096 * 0.65 / 1000 / 2,
     tflops_lofi=4096 * 0.65 / 1000,

--- a/src/tt_perf_report/perf_report.py
+++ b/src/tt_perf_report/perf_report.py
@@ -133,6 +133,7 @@ class ArchitectureSpec:
     name: str
     worker_cores: int
     dram_bandwidth_gb_s: float
+    eth_bandwidth_gb_s: float
     tflops_hifi4: float
     tflops_hifi2: float
     tflops_lofi: float
@@ -168,6 +169,7 @@ class ArchitectureSpec:
                 name=spec.name,
                 worker_cores=worker_cores,
                 dram_bandwidth_gb_s=spec.dram_bandwidth_gb_s,
+                eth_bandwidth_gb_s=spec.eth_bandwidth_gb_s,
                 tflops_hifi4=spec.tflops_hifi4,
                 tflops_hifi2=spec.tflops_hifi2,
                 tflops_lofi=spec.tflops_lofi,
@@ -284,6 +286,7 @@ ArchitectureSpec.register(ArchitectureSpec(
     name="wormhole",
     worker_cores=64,  # N150 and N300 with ETH dispatch
     dram_bandwidth_gb_s=288,
+    eth_bandwidth_gb_s=50,  # 50 GB/s per link
     tflops_hifi4=74 / 72,
     tflops_hifi2=148 / 72,
     tflops_lofi=262 / 72,
@@ -293,6 +296,7 @@ ArchitectureSpec.register(ArchitectureSpec(
     name="blackhole",
     worker_cores=130,  # P150
     dram_bandwidth_gb_s=512,
+    eth_bandwidth_gb_s=50,  # 50 GB/s per link
     tflops_hifi4=4096 * 1.35 / 1000 / 4,
     tflops_hifi2=4096 * 1.35 / 1000 / 2,
     tflops_lofi=4096 * 1.35 / 1000,
@@ -302,6 +306,7 @@ ArchitectureSpec.register(ArchitectureSpec(
     name="bh20",
     worker_cores=20,   # N1-emu
     dram_bandwidth_gb_s=512,
+    eth_bandwidth_gb_s=50,  # 50 GB/s per link
     tflops_hifi4=4096 * 1.35 / 1000 / 4,
     tflops_hifi2=4096 * 1.35 / 1000 / 2,
     tflops_lofi=4096 * 1.35 / 1000,
@@ -311,6 +316,7 @@ ArchitectureSpec.register(ArchitectureSpec(
     name="n1",
     worker_cores=20,
     dram_bandwidth_gb_s=120,
+    eth_bandwidth_gb_s=50,  # 50 GB/s per link
     tflops_hifi4=4096 * 0.65 / 1000 / 4,
     tflops_hifi2=4096 * 0.65 / 1000 / 2,
     tflops_lofi=4096 * 0.65 / 1000,
@@ -679,6 +685,124 @@ def analyze_matmul(row, csv_format=CsvFormat.V2, arch_spec: ArchitectureSpec = N
     )
 
 
+def analyze_ccl(row, csv_format=CsvFormat.V2, arch_spec: ArchitectureSpec = None, op_code: str = ""):
+    """
+    Analyze CCL (Collective Communications Library) operations.
+
+    Formula: data = tensor_size * (ring_size - 1) / ring_size
+    Utilization = (data / duration) / peak_bandwidth
+    """
+    if arch_spec is None:
+        arch_spec = ArchitectureSpec.from_name("wormhole")
+
+    # Parse attributes
+    attributes = row["ATTRIBUTES"] if pd.notna(row["ATTRIBUTES"]) else ""
+
+    # Parse ring_size from attributes
+    ring_size = None
+    try:
+        if "ring_size" in attributes:
+            ring_size_str = attributes.split("'ring_size': '")[1].split("'")[0]
+            ring_size = int(ring_size_str)
+    except (IndexError, ValueError, AttributeError):
+        pass
+
+    # Default ring_size if not found
+    if ring_size is None:
+        ring_size = 4
+
+    # Parse num_links from attributes
+    num_links = None
+    try:
+        if "num_links" in attributes:
+            num_links_str = attributes.split("'num_links': '")[1].split("'")[0]
+            num_links = int(num_links_str)
+    except (IndexError, ValueError, AttributeError):
+        pass
+
+    # Default num_links based on architecture if not found
+    if num_links is None:
+        num_links = 2 if arch_spec.name == "blackhole" else 1
+
+    # Parse topology from attributes
+    topology = None
+    try:
+        if "topology" in attributes:
+            topology_str = attributes.split("'topology': '")[1].split("'")[0]
+            topology = topology_str  # e.g., "Topology::Linear" or "Topology::Ring"
+    except (IndexError, ValueError, AttributeError):
+        pass
+
+    # Calculate tensor sizes for input_0
+    input_0_size = (
+        get_value_physical_logical(row[get_column_name("INPUT_0_Z", csv_format)])
+        * get_value_physical_logical(row[get_column_name("INPUT_0_Y", csv_format)])
+        * get_value_physical_logical(row[get_column_name("INPUT_0_X", csv_format)])
+        * get_datatype_size(row["INPUT_0_DATATYPE"])
+    )
+
+    # Calculate tensor sizes for input_1 (if exists)
+    input_1_size = 0
+    input_1_col = get_column_name("INPUT_1_Z", csv_format)
+    if input_1_col in row.index and pd.notna(row[input_1_col]) and pd.notna(row.get("INPUT_1_DATATYPE")):
+        try:
+            input_1_size = (
+                get_value_physical_logical(row[get_column_name("INPUT_1_Z", csv_format)])
+                * get_value_physical_logical(row[get_column_name("INPUT_1_Y", csv_format)])
+                * get_value_physical_logical(row[get_column_name("INPUT_1_X", csv_format)])
+                * get_datatype_size(row["INPUT_1_DATATYPE"])
+            )
+        except (KeyError, ValueError, TypeError):
+            input_1_size = 0
+
+    # Calculate tensor sizes for output_0
+    output_0_size = (
+        get_value_physical_logical(row[get_column_name("OUTPUT_0_Z", csv_format)])
+        * get_value_physical_logical(row[get_column_name("OUTPUT_0_Y", csv_format)])
+        * get_value_physical_logical(row[get_column_name("OUTPUT_0_X", csv_format)])
+        * get_datatype_size(row["OUTPUT_0_DATATYPE"])
+    )
+
+    # Calculate tensor sizes for output_1 (if exists)
+    output_1_size = 0
+    output_1_col = get_column_name("OUTPUT_1_Z", csv_format)
+    if output_1_col in row.index and pd.notna(row[output_1_col]) and pd.notna(row.get("OUTPUT_1_DATATYPE")):
+        try:
+            output_1_size = (
+                get_value_physical_logical(row[get_column_name("OUTPUT_1_Z", csv_format)])
+                * get_value_physical_logical(row[get_column_name("OUTPUT_1_Y", csv_format)])
+                * get_value_physical_logical(row[get_column_name("OUTPUT_1_X", csv_format)])
+                * get_datatype_size(row["OUTPUT_1_DATATYPE"])
+            )
+        except (KeyError, ValueError, TypeError):
+            output_1_size = 0
+
+    # Select tensor size based on operation type
+    if "ReduceScatter" in op_code:
+        tensor_size = input_0_size
+    elif "AllGather" in op_code:
+        tensor_size = output_0_size
+    else:
+        tensor_size = max(input_0_size, input_1_size, output_0_size, output_1_size)
+
+    # Calculate data transferred: (ring_size - 1) * tensor_size
+    if ring_size > 1:
+        ccl_data_transferred_bytes = tensor_size * (ring_size - 1)
+        ccl_data_transferred_bytes *= 2 if topology == "Topology::Linear" else 1
+    else:
+        ccl_data_transferred_bytes = tensor_size
+
+    # Calculate speed and utilization
+    duration_s = row["DEVICE KERNEL DURATION [ns]"] * 1e-9
+    ccl_speed_gb_s = (ccl_data_transferred_bytes / duration_s) / 1e9 if ccl_data_transferred_bytes > 0 and duration_s > 0 else None
+
+    # Peak bandwidth = eth_bandwidth × num_links
+    peak_ccl_bandwidth = arch_spec.eth_bandwidth_gb_s * num_links * ring_size
+    ccl_percentage = (ccl_speed_gb_s / peak_ccl_bandwidth) * 100 if ccl_speed_gb_s is not None else None
+
+    return (ccl_speed_gb_s, ccl_percentage)
+
+
 def analyze_halo(row):
     attributes = row["ATTRIBUTES"] if pd.notna(row["ATTRIBUTES"]) else ""
 
@@ -821,6 +945,8 @@ def analyze_op(row, prev_row, csv_format=CsvFormat.V2, arch_spec: ArchitectureSp
     dram_percentage = Cell(None, unit="%", decimals=1)
     flops = Cell(None, unit="TFLOPs", decimals=1)
     flops_percentage = Cell(None, unit="%", decimals=1)
+    ccl_speed = Cell(None, unit="GB/s", decimals=0)
+    ccl_percentage = Cell(None, unit="%", decimals=1)
 
     math_fidelity = ""
     math_fidelity += f"{short_name(input_0_datatype)}" if pd.notna(input_0_datatype) else ""
@@ -854,6 +980,14 @@ def analyze_op(row, prev_row, csv_format=CsvFormat.V2, arch_spec: ArchitectureSp
             if math_fidelity
             else None
         )
+    elif any(x in op_code.raw_value for x in ["AllGather", "ReduceScatter", "AllReduce"]) and "LayerNorm" not in op_code.raw_value:
+        # Analyze CCL operations
+        (
+            ccl_speed,
+            ccl_percentage,
+        ) = analyze_ccl(row, csv_format, arch_spec, op_code.raw_value)
+        ccl_speed = Cell(ccl_speed, unit="GB/s", decimals=0)
+        ccl_percentage = Cell(ccl_percentage, unit="%", decimals=1)
     elif any(x in op_code.raw_value for x in ["OptimizedConvNew", "Conv2d"]):
         (
             flops,
@@ -897,6 +1031,8 @@ def analyze_op(row, prev_row, csv_format=CsvFormat.V2, arch_spec: ArchitectureSp
         "DRAM %": dram_percentage,
         "FLOPs": flops,
         "FLOPs %": flops_percentage,
+        "CCL": ccl_speed,
+        "CCL %": ccl_percentage,
         "Math Fidelity": math_fidelity_cell,
         "Output Datatype": output_datatype_cell,
         "Input 0 Datatype": input_0_datatype_cell,
@@ -1997,6 +2133,8 @@ def generate_perf_report(
         "DRAM %",
         "FLOPs",
         "FLOPs %",
+        "CCL",
+        "CCL %",
         "Math Fidelity",
     ]
 

--- a/src/tt_perf_report/perf_report.py
+++ b/src/tt_perf_report/perf_report.py
@@ -723,6 +723,24 @@ def analyze_ccl(row, csv_format=CsvFormat.V2, arch_spec: ArchitectureSpec = None
     except (IndexError, ValueError, AttributeError):
         pass
 
+    experts_per_chip = None
+    try:
+        if "experts_per_chip" in attributes:
+            experts_per_chip_str = attributes.split("'experts_per_chip': '")[1].split("'")[0]
+            experts_per_chip = int(experts_per_chip_str)
+    except (IndexError, ValueError, AttributeError):
+        pass
+
+    num_experts_per_tok = None
+    try:
+        if "num_experts_per_tok" in attributes:
+            num_experts_per_tok_str = attributes.split("'num_experts_per_tok': '")[1].split("'")[0]
+            num_experts_per_tok = int(num_experts_per_tok_str)
+    except (IndexError, ValueError, AttributeError):
+        pass
+
+    total_experts = 256
+
     # Calculate tensor sizes for input_0
     input_0_size = (
         get_value_physical_logical(row[get_column_name("INPUT_0_Z", csv_format)])
@@ -753,11 +771,12 @@ def analyze_ccl(row, csv_format=CsvFormat.V2, arch_spec: ArchitectureSpec = None
         tensor_size = input_0_size
     elif "AllGather" in op_code:
         tensor_size = output_0_size
-    elif "Dispatch" in op_code:
-        tensor_size = input_0_size
-    elif "Combine" in op_code:
+    elif "DispatchDeviceOperation" in op_code:
+        tensor_size = input_0_size * experts_per_chip * num_experts_per_tok / total_experts
+    elif "CombineDeviceOperation" in op_code:
         tensor_size = output_0_size
         tensor_size /= get_value_physical_logical(row[get_column_name("OUTPUT_0_Y", csv_format)])
+        tensor_size *= experts_per_chip * num_experts_per_tok / total_experts
     else:
         tensor_size = max(input_0_size, output_0_size)
 
@@ -975,7 +994,7 @@ def analyze_op(row, prev_row, csv_format=CsvFormat.V2, arch_spec: ArchitectureSp
             if math_fidelity
             else None
         )
-    elif any(x in op_code.raw_value for x in ["AllGather", "ReduceScatter", "AllReduce", "Dispatch", "Combine"]) and "LayerNorm" not in op_code.raw_value:
+    elif any(x in op_code.raw_value for x in ["AllGather", "ReduceScatter", "AllReduce", "DispatchDeviceOperation", "CombineDeviceOperation"]) and "LayerNorm" not in op_code.raw_value:
         # Analyze CCL operations
         (
             ccl_speed,

--- a/src/tt_perf_report/perf_report.py
+++ b/src/tt_perf_report/perf_report.py
@@ -693,7 +693,6 @@ def analyze_ccl(row, csv_format=CsvFormat.V2, arch_spec: ArchitectureSpec = None
     # Parse attributes
     attributes = row["ATTRIBUTES"] if pd.notna(row["ATTRIBUTES"]) else ""
 
-    # Parse num_links from attributes
     num_links = None
     try:
         if "num_links" in attributes:
@@ -706,12 +705,11 @@ def analyze_ccl(row, csv_format=CsvFormat.V2, arch_spec: ArchitectureSpec = None
     if num_links is None:
         num_links = 2 if arch_spec.name == "blackhole" else 1
 
-    # Parse topology from attributes
     topology = None
     try:
         if "topology" in attributes:
             topology_str = attributes.split("'topology': '")[1].split("'")[0]
-            topology = topology_str  # e.g., "Topology::Linear" or "Topology::Ring"
+            topology = topology_str  # "Topology::Linear" or "Topology::Ring"
     except (IndexError, ValueError, AttributeError):
         pass
 
@@ -739,6 +737,7 @@ def analyze_ccl(row, csv_format=CsvFormat.V2, arch_spec: ArchitectureSpec = None
     except (IndexError, ValueError, AttributeError):
         pass
 
+    # Default num_routed_experts in case of DispatchDeviceOperation and CombineDeviceOperation
     if num_routed_experts is None:
         num_routed_experts = 256
 
@@ -773,7 +772,7 @@ def analyze_ccl(row, csv_format=CsvFormat.V2, arch_spec: ArchitectureSpec = None
     elif "ReduceScatter" in op_code and output_0_size > 0:
         ring_size = input_0_size // output_0_size
 
-    # Select tensor size (M) based on operation type
+    # Select tensor size that is used when calculating utilization based on operation type
     if "ReduceScatter" in op_code:
         tensor_size = input_0_size
     elif "AllGather" in op_code:
@@ -783,19 +782,20 @@ def analyze_ccl(row, csv_format=CsvFormat.V2, arch_spec: ArchitectureSpec = None
     elif "CombineDeviceOperation" in op_code:
         tensor_size = output_0_size
         y_dim = get_value_physical_logical(row[get_column_name("OUTPUT_0_Y", csv_format)])
-        if y_dim > 0: # Added safety check against zero division
-            tensor_size /= y_dim
+        if y_dim > 0:
+            tensor_size /= y_dim   # tensor size is y_dim times larger than expected, scale down by y_dim
         tensor_size *= dispatch_group_size * num_experts_per_tok / num_routed_experts
     else:
         tensor_size = max(input_0_size, output_0_size)
 
-    # Calculate effective data transferred per node (Algorithm Bus Bandwidth model)
+    # Calculate effective data transferred per node
     if ring_size is not None and ring_size > 1:
         # All-Gather & Reduce-Scatter logic
         effective_data_moved_bytes = tensor_size * (ring_size - 1) / ring_size
         if topology == "Topology::Linear":
             effective_data_moved_bytes *= 2
     elif dispatch_group_size is not None and dispatch_group_size > 1:
+        # DispatchDeviceOperation & CombineDeviceOperation logic
         if topology == "Topology::Linear":
             effective_data_moved_bytes = tensor_size * (dispatch_group_size ** 2) / 4
         else:
@@ -803,7 +803,7 @@ def analyze_ccl(row, csv_format=CsvFormat.V2, arch_spec: ArchitectureSpec = None
     else:
         effective_data_moved_bytes = tensor_size
 
-    # Calculate speed (Throughput per node) and utilization
+    # Calculate utilization based on effective data transferred per node and duration
     duration_s = row["DEVICE KERNEL DURATION [ns]"] * 1e-9
     
     if effective_data_moved_bytes > 0 and duration_s > 0:

--- a/src/tt_perf_report/perf_report.py
+++ b/src/tt_perf_report/perf_report.py
@@ -995,7 +995,7 @@ def analyze_op(row, prev_row, csv_format=CsvFormat.V2, arch_spec: ArchitectureSp
             if math_fidelity
             else None
         )
-    elif any(x in op_code.raw_value for x in ["AllGather", "ReduceScatter", "AllReduce", "DispatchDeviceOperation", "CombineDeviceOperation"]) and "LayerNorm" not in op_code.raw_value:
+    elif any(x in op_code.raw_value for x in ["AllGatherDeviceOperation", "AllGatherAsyncDeviceOperation", "ReduceScatterDeviceOperation", "ReduceScatterMinimalAsyncDeviceOperation", "DispatchDeviceOperation", "CombineDeviceOperation"]) and "LayerNorm" not in op_code.raw_value:
         # Analyze CCL operations
         (
             ccl_speed,

--- a/src/tt_perf_report/perf_report.py
+++ b/src/tt_perf_report/perf_report.py
@@ -723,14 +723,6 @@ def analyze_ccl(row, csv_format=CsvFormat.V2, arch_spec: ArchitectureSpec = None
     except (IndexError, ValueError, AttributeError):
         pass
 
-    experts_per_chip = None
-    try:
-        if "experts_per_chip" in attributes:
-            experts_per_chip_str = attributes.split("'experts_per_chip': '")[1].split("'")[0]
-            experts_per_chip = int(experts_per_chip_str)
-    except (IndexError, ValueError, AttributeError):
-        pass
-
     num_experts_per_tok = None
     try:
         if "num_experts_per_tok" in attributes:
@@ -739,7 +731,16 @@ def analyze_ccl(row, csv_format=CsvFormat.V2, arch_spec: ArchitectureSpec = None
     except (IndexError, ValueError, AttributeError):
         pass
 
-    total_experts = 256
+    num_routed_experts = None
+    try:
+        if "num_routed_experts" in attributes:
+            num_routed_experts_str = attributes.split("'num_routed_experts': '")[1].split("'")[0]
+            num_routed_experts = int(num_routed_experts_str)
+    except (IndexError, ValueError, AttributeError):
+        pass
+
+    if num_routed_experts is None:
+        num_routed_experts = 256
 
     # Calculate tensor sizes for input_0
     input_0_size = (
@@ -772,11 +773,11 @@ def analyze_ccl(row, csv_format=CsvFormat.V2, arch_spec: ArchitectureSpec = None
     elif "AllGather" in op_code:
         tensor_size = output_0_size
     elif "DispatchDeviceOperation" in op_code:
-        tensor_size = input_0_size * experts_per_chip * num_experts_per_tok / total_experts
+        tensor_size = input_0_size * dispatch_group_size * num_experts_per_tok / num_routed_experts
     elif "CombineDeviceOperation" in op_code:
         tensor_size = output_0_size
         tensor_size /= get_value_physical_logical(row[get_column_name("OUTPUT_0_Y", csv_format)])
-        tensor_size *= experts_per_chip * num_experts_per_tok / total_experts
+        tensor_size *= dispatch_group_size * num_experts_per_tok / num_routed_experts
     else:
         tensor_size = max(input_0_size, output_0_size)
 

--- a/tests/validate_csv_output.py
+++ b/tests/validate_csv_output.py
@@ -38,6 +38,8 @@ def expected_headers():
         "DRAM %",
         "FLOPs",
         "FLOPs %",
+        "CCL",
+        "CCL %",
         "Math Fidelity",
         "Output Datatype",
         "Input 0 Datatype",


### PR DESCRIPTION
Adds CCL utilization in % and GB/s for All Gather, Reduce Scatter, Dispatch and Combine ops.

Formulas used in the PR follow calculation available in this [document](https://docs.google.com/spreadsheets/d/1iSKKFH4191gzDiTrCTQuRsPy2eaiDt5yHw816rJQqXg/edit?usp=sharing). The document uses standard formulas for calculating the amount of data being handled by a single node in different network setups:

<img width="705" height="584" alt="Screenshot 2026-04-27 at 14 31 39" src="https://github.com/user-attachments/assets/6216a2c1-abbf-49db-b68c-d20429487494" />


Example of the DeepSeek v3 prefill perf report after CCL utilization is added (note that this is an old report, so the actual values may vary with the current implementation of the model):
<img width="1397" height="969" alt="Screenshot 2026-04-27 at 14 37 25" src="https://github.com/user-attachments/assets/a7a58a34-a320-426f-a06a-cbd8ec22d524" />

<img width="1397" height="223" alt="Screenshot 2026-04-27 at 14 38 01" src="https://github.com/user-attachments/assets/e5c85fe0-c567-4cf7-9a4d-264d31587940" />
