### PR TITLE
Support HiFi3 math fidelity

### DIFF
--- a/src/tt_perf_report/perf_report.py
+++ b/src/tt_perf_report/perf_report.py
@@ -533,12 +533,6 @@ def pad_string(string, length, align="left"):
 def evaluate_fidelity(
     input_0_datatype, input_1_datatype, output_datatype, math_fidelity
 ):
-    if math_fidelity == "HiFi3":
-        return (
-            "unknown",
-            "HiFi3 is supported for throughput analysis, but fidelity advice is not yet defined.",
-        )
-
     integer_types = {"UINT8", "UINT16", "INT32", "UINT32"}
 
     if (
@@ -549,6 +543,12 @@ def evaluate_fidelity(
         return (
             "not_applicable",
             "Fidelity evaluation is not applicable for integer datatypes (UINT8, UINT16, INT32, UINT32).",
+        )
+
+    if math_fidelity == "HiFi3":
+        return (
+            "unknown",
+            "HiFi3 is supported for throughput analysis, but fidelity advice is not yet defined.",
         )
 
     mantissa_bits = {"FLOAT32": 23, "BFLOAT16": 8, "BFLOAT8_B": 7, "BFLOAT4_B": 3}

--- a/src/tt_perf_report/perf_report.py
+++ b/src/tt_perf_report/perf_report.py
@@ -294,6 +294,7 @@ class ArchitectureSpec:
         """Get TFLOPs per core for given math fidelity."""
         fidelity_map = {
             "HiFi4": self.tflops_hifi4,
+            "HiFi3": self.tflops_lofi / 3,
             "HiFi2": self.tflops_hifi2,
             "LoFi": self.tflops_lofi,
         }
@@ -532,6 +533,12 @@ def pad_string(string, length, align="left"):
 def evaluate_fidelity(
     input_0_datatype, input_1_datatype, output_datatype, math_fidelity
 ):
+    if math_fidelity == "HiFi3":
+        return (
+            "unknown",
+            "HiFi3 is supported for throughput analysis, but fidelity advice is not yet defined.",
+        )
+
     integer_types = {"UINT8", "UINT16", "INT32", "UINT32"}
 
     if (

--- a/tests/test_validate_csv_output.py
+++ b/tests/test_validate_csv_output.py
@@ -70,6 +70,14 @@ def test_hifi3_is_supported_for_throughput_and_advice_paths():
         "HiFi3 is supported for throughput analysis, but fidelity advice is not yet defined.",
     )
 
+
+def test_hifi3_integer_datatypes_keep_not_applicable_advice():
+    assert evaluate_fidelity("UINT8", "BFLOAT16", "BFLOAT16", "HiFi3") == (
+        "not_applicable",
+        "Fidelity evaluation is not applicable for integer datatypes (UINT8, UINT16, INT32, UINT32).",
+    )
+
+
 # TT-NN Visualizer default request
 def test_csv_headers_with_all_options(expected_headers, test_csv_content, mocker):
     with tempfile.NamedTemporaryFile(

--- a/tests/test_validate_csv_output.py
+++ b/tests/test_validate_csv_output.py
@@ -10,7 +10,13 @@ import re
 from io import StringIO
 import pytest
 import pandas as pd
-from tt_perf_report.perf_report import generate_perf_report, detect_csv_format, CsvFormat, ArchitectureSpec
+from tt_perf_report.perf_report import (
+    generate_perf_report,
+    detect_csv_format,
+    CsvFormat,
+    ArchitectureSpec,
+    evaluate_fidelity,
+)
 
 # Shared test data (sample output from TT-NN)
 @pytest.fixture(scope="session")
@@ -51,6 +57,18 @@ def expected_headers():
         "Advice",
         "Raw OP Code",
     ]
+
+
+def test_hifi3_is_supported_for_throughput_and_advice_paths():
+    arch = ArchitectureSpec.from_name("wormhole", 64)
+
+    assert arch.tflops_per_core("HiFi3") == pytest.approx(
+        arch.tflops_per_core("LoFi") / 3
+    )
+    assert evaluate_fidelity("BFLOAT16", "BFLOAT16", "BFLOAT16", "HiFi3") == (
+        "unknown",
+        "HiFi3 is supported for throughput analysis, but fidelity advice is not yet defined.",
+    )
 
 # TT-NN Visualizer default request
 def test_csv_headers_with_all_options(expected_headers, test_csv_content, mocker):


### PR DESCRIPTION
# Summary

- Adds HiFi3 math-fidelity handling for Wormhole architecture throughput calculations.
- Keeps `evaluate_fidelity` from crashing on HiFi3 and returns an explicit unknown classification when advice cannot be produced.
- Preserves integer datatype `not_applicable` advice when `math_fidelity` is `HiFi3`.

# Validation

- `.venv/bin/python -m py_compile src/tt_perf_report/perf_report.py tests/test_validate_csv_output.py`
- `.venv/bin/python -m pytest tests/test_validate_csv_output.py -q` -> `17 passed`

# Context

- Supports tt-xla#5009 live IRD profiling, where Tracy output from the bounded MNIST run contained HiFi3 rows.
- Without this change, `tt-perf-report` fails with `ValueError: Unknown math fidelity: HiFi3` during report generation.

# Review Note

- The current `HiFi3` throughput formula is inferred from the existing fidelity pattern in this repo: `HiFi4 = LoFi / 4`, `HiFi2 = LoFi / 2`, and `LoFi = LoFi`, so this PR uses `HiFi3 = LoFi / 3`.
- I did not find a repo-local HiFi3 throughput constant or formula. Maintainers should confirm this value or replace it with the correct hardware value during review.

